### PR TITLE
add initialization callback with kwargs

### DIFF
--- a/Blankly/strategy/strategy_base.py
+++ b/Blankly/strategy/strategy_base.py
@@ -55,7 +55,7 @@ class Strategy:
         hashed = hash(callable)
         self.__variables[hashed][key] = value
 
-    def add_price_event(self, callback: typing.Callable, currency_pair: str, resolution: str):
+    def add_price_event(self, callback: typing.Callable, currency_pair: str, resolution: str, init: typing.Callable = None, **kwargs):
         """
         Add Orderbook Event
         Args:
@@ -66,8 +66,12 @@ class Strategy:
         resolution = time_interval_to_seconds(resolution)
         
         self.__scheduling_pair.append([currency_pair, resolution])
-        callback_id = hash(callback)
-        self.__variables[callback_id] = AttributeDict({})
+        self.__variables[callback] = AttributeDict({})
+        state = StrategyState(self, self.Interface, self.__variables[callback], resolution)
+
+        # run init
+        if init:
+            init(currency_pair, state)
 
         if resolution < 10:
             # since it's less than 10 sec, we will just use the websocket feed - exchanges don't like fast calls
@@ -77,9 +81,9 @@ class Strategy:
                                   initially_stopped=True,
                                   callback=callback,
                                   resolution=resolution,
-                                  variables=self.__variables[callback_id],
-                                  state_object=StrategyState(self, self.Interface, self.__variables[callback_id], resolution),
-                                  currency_pair=currency_pair)
+                                  variables=self.__variables[callback],
+                                  state_object=state,
+                                  currency_pair=currency_pair, **kwargs)
             )
         else:
             # Use the API
@@ -88,9 +92,9 @@ class Strategy:
                                   initially_stopped=True,
                                   callback=callback,
                                   resolution=resolution,
-                                  variables=self.__variables[callback_id],
-                                  state_object=StrategyState(self, self.Interface, self.__variables[callback_id], resolution),
-                                  currency_pair=currency_pair)
+                                  variables=self.__variables[callback],
+                                  state_object=state,
+                                  currency_pair=currency_pair, **kwargs)
             )
 
     def __idle_event(self):
@@ -131,7 +135,7 @@ class Strategy:
     def __orderbook_event(self, tick, currency_pair, user_callback, state_object):
         user_callback(tick, currency_pair, state_object)
 
-    def add_orderbook_event(self, callback: typing.Callable, currency_pair: str):
+    def add_orderbook_event(self, callback: typing.Callable, currency_pair: str, init: typing.Callable = None, **kwargs):
         """
         Add Orderbook Event
         Args:
@@ -141,6 +145,9 @@ class Strategy:
         self.__scheduling_pair.append([currency_pair, 'live'])
         callback_id = str(uuid4())
         self.__variables[callback_id] = AttributeDict({})
+        state = StrategyState(self, self.Interface, self.__variables[callback])
+        if init:
+            init(currency_pair, state)
 
         variables = self.__variables[callback_id]
 
@@ -149,7 +156,8 @@ class Strategy:
                                                 currency_id=currency_pair,
                                                 currency_pair=currency_pair,
                                                 user_callback=callback,
-                                                state_object=StrategyState(self, self.Interface, variables)
+                                                state_object=state,
+                                                **kwargs
                                                 )
 
         exchange_type = self.__exchange.get_type()

--- a/Blankly/strategy/strategy_base.py
+++ b/Blankly/strategy/strategy_base.py
@@ -55,13 +55,16 @@ class Strategy:
         hashed = hash(callable)
         self.__variables[hashed][key] = value
 
-    def add_price_event(self, callback: typing.Callable, currency_pair: str, resolution: str, init: typing.Callable = None, **kwargs):
+    def add_price_event(self, callback: typing.Callable, currency_pair: str, resolution: str,
+                        init: typing.Callable = None, **kwargs):
         """
         Add Orderbook Event
         Args:
             callback: The price event callback that will be added to the current ticker and run at the proper resolution
             currency_pair: Currency pair to create the price event for
             resolution: The resolution that the callback will be run - in seconds
+            init: Callback function to allow a setup for the strategy variable. This
+                can be used for accumulating price data
         """
         resolution = time_interval_to_seconds(resolution)
         


### PR DESCRIPTION
This PR adds the ability to run an init callback to initialize state variables. It also adds the ability to pass in kwarg parameters to price event functions if users wish to add them. A key example is shown below: 

```python
import Blankly
from Blankly import Strategy, Alpaca

def init(ticker: str, state: Blankly.StrategyState):
    # init prices
    state.variables.prices = state.interface.get_product_history(50, '1d')['close']
    state.variables['has_bought'] = False

def price_event(price: float, ticker: str, state: Blankly.StrategyState, position_size: float=0.35):
     interface = state.interface
     state.variables.prices.append(price)
     state.variables['has_bought'] = True
     interface.market_order(interface.cash * position_size)

a = Alpaca()
s = Strategy(a)

# Allows the user to create varying portfolio allocations for varying assets within the same strategy
s.add_price_event("MSFT", resolution="15m", init=init, position_size=0.25)
s.add_price_event("AAPL", resolution="15m", init=init, position_size=0.45)
```