### PR TITLE
Interface Attributes, Cash Parameter, and Alpaca Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+keys.json
 
 # Pyre type checker
 .pyre/

--- a/Blankly/auth/direct_calls_factory.py
+++ b/Blankly/auth/direct_calls_factory.py
@@ -43,11 +43,11 @@ class InterfaceFactory:
         elif exchange_name == 'binance':
             if preferences["settings"]["use_sandbox"] or preferences["settings"]["paper_trade"]:
                 calls = Client(api_key=auth.keys['API_KEY'], api_secret=auth.keys['API_SECRET'],
-                               tld=preferences["settings"]["binance_tld"],
+                               tld=preferences["settings"]['binance']["binance_tld"],
                                testnet=True)
             else:
                 calls = Client(api_key=auth.keys['API_KEY'], api_secret=auth.keys['API_SECRET'],
-                               tld=preferences["settings"]["binance_tld"])
+                               tld=preferences["settings"]['binance']["binance_tld"])
             return calls, BinanceInterface(exchange_name, calls)
 
         elif exchange_name == 'alpaca':

--- a/Blankly/exchanges/Alpaca/Alpaca_API.py
+++ b/Blankly/exchanges/Alpaca/Alpaca_API.py
@@ -30,5 +30,6 @@ api = os.getenv("ALPACA_PUBLIC")
 secret = os.getenv("ALPACA_PRIVATE")
 
 if __name__ == "__main__":
+    # TODO: Update this main test
     client = API(api, secret, True)
     print(client.alp_client.list_assets())

--- a/Blankly/exchanges/Alpaca/alpaca_api_interface.py
+++ b/Blankly/exchanges/Alpaca/alpaca_api_interface.py
@@ -93,7 +93,7 @@ class AlpacaInterface(CurrencyInterface):
         for key in positions_dict:
             positions_dict[key] = utils.isolate_specific(needed, positions_dict[key])
 
-        positions_dict.cash = account_dict.pop('cash')
+        positions_dict.cash = float(account_dict.pop('cash'))
 
         if currency is not None:
             # if we haven't found the currency, then we'll end up here

--- a/Blankly/exchanges/Binance/Binance_Interface.py
+++ b/Blankly/exchanges/Binance/Binance_Interface.py
@@ -154,7 +154,7 @@ class BinanceInterface(CurrencyInterface):
             products[i] = utils.isolate_specific(needed, products[i])
         return products
 
-    def get_account(self, currency=None) -> dict:
+    def get_account(self, currency=None) -> utils.AttributeDict:
         """
         Get all currencies in an account, or sort by currency/account_id
         Args:

--- a/Blankly/exchanges/Binance/Binance_Interface.py
+++ b/Blankly/exchanges/Binance/Binance_Interface.py
@@ -208,16 +208,16 @@ class BinanceInterface(CurrencyInterface):
                     if accounts[i]["asset"] == currency:
                         accounts = utils.rename_to(renames, accounts[i])
                         parsed_value = utils.isolate_specific(needed, accounts)
-                        return {
+                        return utils.AttributeDict({
                             'available': parsed_value['available'],
                             'hold': parsed_value['hold']
-                        }
+                        })
                 # If not just return a default 0 value. This is safe because we already checked if the currency
                 #  was valid
-                return {
+                return utils.AttributeDict({
                     "available": 0.0,
                     "hold": 0.0
-                }
+                })
             else:
                 raise LookupError("Currency not found")
 
@@ -238,18 +238,18 @@ class BinanceInterface(CurrencyInterface):
                     # Do the normal thing above and append
                     mutated = utils.rename_to(renames, val)
                     mutated = utils.isolate_specific(needed, mutated)
-                    parsed_dictionary[mutated['currency']] = {
+                    parsed_dictionary[mutated['currency']] = utils.AttributeDict({
                         'available': mutated['available'],
                         'hold': mutated['hold']
-                    }
+                    })
                     found = True
             # If it wasn't found just default here
             if not found:
-                parsed_dictionary[i] = {
+                parsed_dictionary[i] = utils.AttributeDict({
                     'available': 0.0,
                     'hold': 0.0
-                }
-        return parsed_dictionary
+                })
+        return utils.AttributeDict(parsed_dictionary)
 
     def market_order(self, product_id, side, funds) -> MarketOrder:
         """

--- a/Blankly/exchanges/Coinbase_Pro/Coinbase_Pro_Interface.py
+++ b/Blankly/exchanges/Coinbase_Pro/Coinbase_Pro_Interface.py
@@ -81,7 +81,7 @@ class CoinbaseProInterface(CurrencyInterface):
             products[i] = utils.isolate_specific(needed, products[i])
         return products
 
-    def get_account(self, currency=None) -> dict:
+    def get_account(self, currency=None) -> utils.AttributeDict:
         """
         Get all currencies in an account, or sort by currency/account_id
         Args:
@@ -130,7 +130,7 @@ class CoinbaseProInterface(CurrencyInterface):
                 'hold': account['hold']
             })
 
-        return utils.AttributeDict({parsed_dictionary})
+        return utils.AttributeDict(parsed_dictionary)
 
     def market_order(self, product_id, side, funds) -> MarketOrder:
         """

--- a/Blankly/exchanges/Coinbase_Pro/Coinbase_Pro_Interface.py
+++ b/Blankly/exchanges/Coinbase_Pro/Coinbase_Pro_Interface.py
@@ -117,20 +117,20 @@ class CoinbaseProInterface(CurrencyInterface):
             for i in accounts:
                 if i["currency"] == currency:
                     parsed_value = utils.isolate_specific(needed, i)
-                    return {
+                    return utils.AttributeDict({
                         'available': parsed_value['available'],
                         'hold': parsed_value['hold']
-                    }
+                    })
             raise ValueError("Currency not found")
         for i in range(len(accounts)):
             account = utils.isolate_specific(needed, accounts[i])
 
-            parsed_dictionary[account['currency']] = {
+            parsed_dictionary[account['currency']] = utils.AttributeDict({
                 'available': account['available'],
                 'hold': account['hold']
-            }
+            })
 
-        return parsed_dictionary
+        return utils.AttributeDict({parsed_dictionary})
 
     def market_order(self, product_id, side, funds) -> MarketOrder:
         """

--- a/Blankly/interface/abc_currency_interface.py
+++ b/Blankly/interface/abc_currency_interface.py
@@ -71,10 +71,6 @@ class ICurrencyInterface(abc.ABC):
     def account(self):
         """
         Get all currencies in an account, or sort by currency/account_id
-        Args:
-            currency (Optional): Filter by particular currency
-
-            These arguments are mutually exclusive
 
         TODO add return example
         """
@@ -133,9 +129,15 @@ class ICurrencyInterface(abc.ABC):
     def orders(self):
         """
         List open orders.
-        Args:
-            product_id (optional) (str): Currency pair such as BTC-USD
         TODO add return example
+        """
+        pass
+
+    @property
+    @abc.abstractmethod
+    def cash(self):
+        """
+        Get the amount of cash in a portfolio. The cash default is set in the settings .json file
         """
         pass
 

--- a/Blankly/interface/abc_currency_interface.py
+++ b/Blankly/interface/abc_currency_interface.py
@@ -175,7 +175,6 @@ class ICurrencyInterface(abc.ABC):
         get_withdraw_history
 
     """
-    @property
     @abc.abstractmethod
     def history(self, product_id, epoch_start, epoch_stop, granularity):
         """

--- a/Blankly/interface/abc_currency_interface.py
+++ b/Blankly/interface/abc_currency_interface.py
@@ -65,6 +65,20 @@ class ICurrencyInterface(abc.ABC):
         TODO add return example
         """
         pass
+    
+    @property
+    @abc.abstractmethod
+    def account(self):
+        """
+        Get all currencies in an account, or sort by currency/account_id
+        Args:
+            currency (Optional): Filter by particular currency
+
+            These arguments are mutually exclusive
+
+        TODO add return example
+        """
+        pass
 
     @abc.abstractmethod
     def get_account(self, currency=None) -> dict:
@@ -114,6 +128,17 @@ class ICurrencyInterface(abc.ABC):
         TODO add return example
         """
 
+    @property
+    @abc.abstractmethod
+    def orders(self):
+        """
+        List open orders.
+        Args:
+            product_id (optional) (str): Currency pair such as BTC-USD
+        TODO add return example
+        """
+        pass
+
     @abc.abstractmethod
     def get_open_orders(self, product_id=None):
         """
@@ -150,6 +175,21 @@ class ICurrencyInterface(abc.ABC):
         get_withdraw_history
 
     """
+    @property
+    @abc.abstractmethod
+    def history(self, product_id, epoch_start, epoch_stop, granularity):
+        """
+        Property Function that Returns the product history from an exchange
+        Args:
+            product_id: Blankly product ID format (BTC-USD)
+            epoch_start: Time to begin download
+            epoch_stop: Time to stop download
+            granularity: Resolution in seconds between tick (ex: 60 = 1 per minute)
+        Returns:
+            Dataframe with *at least* 'time (epoch)', 'low', 'high', 'open', 'close', 'volume' as columns.
+            TODO add return example
+        """
+        pass
 
     @abc.abstractmethod
     def get_product_history(self, product_id, epoch_start, epoch_stop, granularity) -> pandas.DataFrame:

--- a/Blankly/interface/currency_Interface.py
+++ b/Blankly/interface/currency_Interface.py
@@ -156,7 +156,6 @@ class CurrencyInterface(ICurrencyInterface, abc.ABC):
     def orders(self):
         return self.get_open_orders()
 
-    @property
     def history(self, product_id, epoch_start, epoch_stop, granularity):
         self.get_product_history(product_id, epoch_start, epoch_stop, granularity)
 

--- a/Blankly/interface/currency_Interface.py
+++ b/Blankly/interface/currency_Interface.py
@@ -148,6 +148,18 @@ class CurrencyInterface(ICurrencyInterface, abc.ABC):
     def get_exchange_type(self):
         return self.exchange_name
 
+    @property
+    def account(self):
+        return self.get_account()
+
+    @property
+    def orders(self):
+        return self.get_open_orders()
+
+    @property
+    def history(self, product_id, epoch_start, epoch_stop, granularity):
+        self.get_product_history(product_id, epoch_start, epoch_stop, granularity)
+
     def get_account(self, currency=None):
         """
         Get all currencies in an account, or sort by currency/account_id

--- a/Blankly/interface/currency_Interface.py
+++ b/Blankly/interface/currency_Interface.py
@@ -156,6 +156,11 @@ class CurrencyInterface(ICurrencyInterface, abc.ABC):
     def orders(self):
         return self.get_open_orders()
 
+    @property
+    def cash(self):
+        using_setting = self.user_preferences['settings'][self.exchange_name]['cash']
+        return self.get_account(using_setting)
+
     def history(self, product_id, epoch_start, epoch_stop, granularity):
         self.get_product_history(product_id, epoch_start, epoch_stop, granularity)
 

--- a/Blankly/utils/ci_utils/Settings.json
+++ b/Blankly/utils/ci_utils/Settings.json
@@ -2,7 +2,18 @@
   "settings": {
     "account_update_time": 5000,
     "use_sandbox": true,
-    "binance_tld": "us",
-    "websocket_buffer_size": 10000
+    "use_sandbox_websockets": false,
+    "websocket_buffer_size": 10000,
+
+    "coinbase_pro": {
+      "cash": "USD"
+    },
+    "binance": {
+      "cash": "USDT",
+      "binance_tld": "us"
+    },
+    "alpaca": {
+      "cash": "USD"
+    }
   }
 }

--- a/Blankly/utils/utils.py
+++ b/Blankly/utils/utils.py
@@ -16,8 +16,8 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-import datetime as DT
-import dateutil.parser as DP
+import datetime as dt
+import dateutil.parser as dp
 import json
 import numpy
 import warnings
@@ -56,13 +56,23 @@ backteset_path_override = None
 
 # Copy of settings to compare defaults vs overrides
 default_global_settings = {
-    "settings": {
-        "account_update_time": 5000,
-        "use_sandbox": False,
-        "use_sandbox_websockets": False,
-        "binance_tld": "us",
-        "websocket_buffer_size": 100000,
+  "settings": {
+    "account_update_time": 5000,
+    "use_sandbox": False,
+    "use_sandbox_websockets": False,
+    "websocket_buffer_size": 10000,
+
+    "coinbase_pro": {
+      "cash": "USD"
+    },
+    "binance": {
+      "cash": "USDT",
+      "binance_tld": "us"
+    },
+    "alpaca": {
+      "cash": "USD"
     }
+  }
 }
 
 default_backtest_settings = {
@@ -72,7 +82,8 @@ default_backtest_settings = {
     "show_tickers_with_zero_delta": False,
     "save_initial_account_value": False,
     "show_progress_during_backtest": False,
-    "cache_location": "./price_caches"
+    "cache_location": "./price_caches",
+    "resample_account_value_for_metrics": "1d"
 }
 
 
@@ -157,11 +168,11 @@ def pretty_print_JSON(json_object):
 
 
 def epoch_from_ISO8601(ISO8601) -> float:
-    return DP.parse(ISO8601).timestamp()
+    return dp.parse(ISO8601).timestamp()
 
 
 def ISO8601_from_epoch(epoch) -> str:
-    return DT.datetime.utcfromtimestamp(epoch).isoformat() + 'Z'
+    return dt.datetime.utcfromtimestamp(epoch).isoformat() + 'Z'
 
 
 def get_price_derivative(ticker, point_number):

--- a/Examples/settings.json
+++ b/Examples/settings.json
@@ -3,7 +3,17 @@
     "account_update_time": 5000,
     "use_sandbox": true,
     "use_sandbox_websockets": false,
-    "binance_tld": "us",
-    "websocket_buffer_size": 10000
+    "websocket_buffer_size": 10000,
+
+    "coinbase_pro": {
+      "cash": "USD"
+    },
+    "binance": {
+      "cash": "USDT",
+      "binance_tld": "us"
+    },
+    "alpaca": {
+      "cash": "USD"
+    }
   }
 }

--- a/tests/config/settings.json
+++ b/tests/config/settings.json
@@ -3,7 +3,17 @@
     "account_update_time": 5000,
     "use_sandbox": true,
     "use_sandbox_websockets": false,
-    "binance_tld": "us",
-    "websocket_buffer_size": 10000
+    "websocket_buffer_size": 10000,
+
+    "coinbase_pro": {
+      "cash": "USD"
+    },
+    "binance": {
+      "cash": "USDT",
+      "binance_tld": "us"
+    },
+    "alpaca": {
+      "cash": "USD"
+    }
   }
 }

--- a/tests/exchanges/Binance/test_Binance_Interface.py
+++ b/tests/exchanges/Binance/test_Binance_Interface.py
@@ -23,7 +23,7 @@ import unittest
 from Blankly.auth.Binance.auth import BinanceAuth
 from Blankly.auth.direct_calls_factory import InterfaceFactory
 from Blankly.exchanges.Binance.Binance_Interface import BinanceInterface
-from Blankly.utils.utils import compare_dictionaries
+from Blankly.utils.utils import compare_dictionaries, AttributeDict
 from pathlib import Path
 import time
 
@@ -57,7 +57,7 @@ def test_get_exchange(binance_interface: BinanceInterface) -> None:
 
 def test_get_account(binance_interface: BinanceInterface) -> None:
     resp = binance_interface.get_account()
-    assert type(resp) is dict
+    assert type(resp) is AttributeDict
 
     found_btc = False
     for asset in resp.keys():

--- a/tests/exchanges/alpaca/alpaca_api_interface_test.py
+++ b/tests/exchanges/alpaca/alpaca_api_interface_test.py
@@ -134,28 +134,23 @@ def test_get_products(alpaca_mock_interface) -> None:
 def test_get_account(alpaca_mock_interface) -> None:
     return_val = alpaca_mock_interface.get_account()
 
-    expected_answer = [
-        {
-            "currency": "USD",
-            "available": 1500,
-            "hold": -1,
-        },
-        {
-            "currency": "AAPL",
+    expected_answer = {
+        "AAPL": {
             "available": 5,
-            "hold": -1,
+            "hold": 0,
         }
-    ]
-
+    }
+    print(return_val)
     for answer in expected_answer:
         found = False
         for result in return_val:
-            if is_sub_dict(answer, result):
-                found = True
+            if result != 'cash':
+                if is_sub_dict(expected_answer[answer], return_val[result]):
+                    found = True
 
         assert found, "expected return element not found: %r" % answer
-
-    assert "exchange_specific" in return_val[0]
+    assert return_val['cash'] == float(1500)
+    # assert "exchange_specific" in return_val[0]
 
 def test_get_fees(alpaca_mock_interface) -> None:
     fee_response = alpaca_mock_interface.get_fees()

--- a/tests/exchanges/alpaca/alpaca_interface_functional_test.py
+++ b/tests/exchanges/alpaca/alpaca_interface_functional_test.py
@@ -80,5 +80,4 @@ def test_get_product_history(alpaca_interface: AlpacaInterface) -> None:
 
     return_df = alpaca_interface.get_product_history("AAPL", start, end, 60)
 
-    print(return_df)
-    assert False
+    assert(return_df.iloc[0]['open'] == 126.6)


### PR DESCRIPTION
## Updated Parameters

This adds the ability to access an account via a property parameter `interface.account` along with `interface.get_account()`, it does the same with `get_product_history()` and `get_orders()`

An example is shown:

```python
import Blankly
from Blankly import Alpaca
a = Alpaca()
interface: Blankly.Interface = a.Interface
# orders = interface.get_orders()
orders = interface.orders # this calls interface.get_orders() under the hood

history = interface.history(...) # this calls interface.get_product_history() under the hood
account = interface.account # calls interface.get_account()
```

## Alpaca Updates

`get_account()` for alpaca should return a `dict` type instead of a `list` type, this has been changed 

## TODO: Cash Settings for Binance and Coinbase_Pro Interfaces
@EmersonDove 