### PR TITLE
Changes and Updates to history()

### DIFF
--- a/blankly/exchanges/interfaces/abc_exchange_interface.py
+++ b/blankly/exchanges/interfaces/abc_exchange_interface.py
@@ -197,8 +197,8 @@ class ABCExchangeInterface(abc.ABC):
                 symbol: str, 
                 to: Union[str, int]=200, 
                 resolution: str='1d', 
-                start_date: Union[str, datetime]=None, 
-                end_date: Union[str, datetime]=None) -> pandas.DataFrame:
+                start_date: Union[str, datetime, float]=None, 
+                end_date: Union[str, datetime, float]=None) -> pandas.DataFrame:
         """
         Wrapper for .get_product_history() which allows users to more easily get product history from right now.
         Args:
@@ -206,8 +206,8 @@ class ABCExchangeInterface(abc.ABC):
             to (str or int): The number of data points back in time either expressed as a string ("1y" meaning 1 year back") 
                 or int of points (300 points at specified resolution)
             resolution: Resolution as a string (i.e. "1d", "4h", "1y")
-            start_date (str or datetime): Start Date for data gathering
-            end_date (str or datetime): End Date for data gathering
+            start_date (str or datetime or float): Start Date for data gathering (in either string, datetime or epoch timestamp)
+            end_date (str or datetime or float): End Date for data gathering (in either string, datetime or epoch timestamp)
         Returns:
             Dataframe with *at least* 'time (epoch)', 'low', 'high', 'open', 'close', 'volume' as columns.
             TODO add return example

--- a/blankly/exchanges/interfaces/abc_exchange_interface.py
+++ b/blankly/exchanges/interfaces/abc_exchange_interface.py
@@ -21,6 +21,7 @@ import abc
 from blankly.exchanges.orders.limit_order import LimitOrder
 from blankly.exchanges.orders.market_order import MarketOrder
 import pandas
+from datetime import datetime
 from typing import Union
 
 
@@ -192,16 +193,21 @@ class ABCExchangeInterface(abc.ABC):
 
     """
     @abc.abstractmethod
-    def history(self,
-                symbol: str,
-                to: Union[str, int, float],
-                resolution: Union[str, float]) -> pandas.DataFrame:
+    def history(self, 
+                symbol: str, 
+                to: Union[str, int]=200, 
+                resolution: str='1d', 
+                start_date: Union[str, datetime]=None, 
+                end_date: Union[str, datetime]=None) -> pandas.DataFrame:
         """
         Wrapper for .get_product_history() which allows users to more easily get product history from right now.
         Args:
-            symbol: The asset such as (BTC-USD, or MSFT)
-            to (str or number): The amount of time before now to get product history
-            resolution: Resolution in seconds between tick (ex: 60 = 1 per minute)
+            product_id: Blankly product ID format (BTC-USD)
+            to (str or int): The number of data points back in time either expressed as a string ("1y" meaning 1 year back") 
+                or int of points (300 points at specified resolution)
+            resolution: Resolution as a string (i.e. "1d", "4h", "1y")
+            start_date (str or datetime): Start Date for data gathering
+            end_date (str or datetime): End Date for data gathering
         Returns:
             Dataframe with *at least* 'time (epoch)', 'low', 'high', 'open', 'close', 'volume' as columns.
             TODO add return example

--- a/blankly/exchanges/interfaces/exchange_interface.py
+++ b/blankly/exchanges/interfaces/exchange_interface.py
@@ -166,7 +166,7 @@ class ExchangeInterface(ABCExchangeInterface, abc.ABC):
         using_setting = self.user_preferences['settings'][self.exchange_name]['cash']
         return self.get_account(using_setting)['available']
 
-    def history(self, symbol, num_points=200, resolution='1d', start_date=None, end_date=None):
+    def history(self, symbol: str, to=200, resolution: str='1d', start_date=None, end_date=None):
         if end_date is None:
             epoch_stop = time.time()
         else:
@@ -176,8 +176,11 @@ class ExchangeInterface(ABCExchangeInterface, abc.ABC):
         resolution_seconds = time_interval_to_seconds(resolution)
 
         if start_date is None:
-            # use number of points to calculate the start epoch
-            epoch_start = epoch_stop - num_points * resolution_seconds
+            if isinstance(to, int):
+                # use number of points to calculate the start epoch
+                epoch_start = epoch_stop - to * resolution_seconds
+            else:
+                epoch_start = epoch_stop - time_interval_to_seconds(to)
         else:
             epoch_start = utils.convert_input_to_epoch(start_date)
 

--- a/blankly/exchanges/interfaces/exchange_interface.py
+++ b/blankly/exchanges/interfaces/exchange_interface.py
@@ -166,10 +166,22 @@ class ExchangeInterface(ABCExchangeInterface, abc.ABC):
         using_setting = self.user_preferences['settings'][self.exchange_name]['cash']
         return self.get_account(using_setting)['available']
 
-    def history(self, symbol, to, resolution):
-        epoch_stop = time.time()
-        epoch_start = epoch_stop - time_interval_to_seconds(to)
-        return self.get_product_history(symbol, epoch_start, epoch_stop, resolution)
+    def history(self, symbol, num_points=200, resolution='1d', start_date=None, end_date=None):
+        if end_date is None:
+            epoch_stop = time.time()
+        else:
+            epoch_stop = utils.convert_input_to_epoch(end_date)
+
+        # convert resolution into epoch seconds    
+        resolution_seconds = time_interval_to_seconds(resolution)
+
+        if start_date is None:
+            # use number of points to calculate the start epoch
+            epoch_start = epoch_stop - num_points * resolution_seconds
+        else:
+            epoch_start = utils.convert_input_to_epoch(start_date)
+
+        return self.get_product_history(symbol, epoch_start, epoch_stop, resolution_seconds)
 
     def get_account(self, symbol=None):
         """

--- a/blankly/utils/utils.py
+++ b/blankly/utils/utils.py
@@ -171,6 +171,13 @@ def pretty_print_JSON(json_object, actually_print=True):
 def epoch_from_ISO8601(ISO8601) -> float:
     return dp.parse(ISO8601).timestamp()
 
+def convert_input_to_epoch(value) -> float:
+    if isinstance(value, str):
+        return dp.parse(value).timestamp()
+    elif isinstance(value, dt.datetime):
+        return value.timestamp()
+    
+    raise ValueError("Incorrect value input given, expected string or value but got: {}".format(type(value)))
 
 def ISO8601_from_epoch(epoch) -> str:
     return dt.datetime.utcfromtimestamp(epoch).isoformat() + 'Z'

--- a/blankly/utils/utils.py
+++ b/blankly/utils/utils.py
@@ -177,7 +177,8 @@ def convert_input_to_epoch(value: Union[str, dt.datetime]) -> float:
         return dp.parse(value).timestamp()
     elif isinstance(value, dt.datetime):
         return value.timestamp()
-    
+    elif isinstance(value, float):
+        return value
     raise ValueError("Incorrect value input given, expected string or value but got: {}".format(type(value)))
 
 def ISO8601_from_epoch(epoch) -> str:

--- a/blankly/utils/utils.py
+++ b/blankly/utils/utils.py
@@ -22,6 +22,7 @@ import json
 import numpy
 import warnings
 import sys
+from typing import Union
 
 from sklearn.linear_model import LinearRegression
 
@@ -171,7 +172,7 @@ def pretty_print_JSON(json_object, actually_print=True):
 def epoch_from_ISO8601(ISO8601) -> float:
     return dp.parse(ISO8601).timestamp()
 
-def convert_input_to_epoch(value) -> float:
+def convert_input_to_epoch(value: Union[str, dt.datetime]) -> float:
     if isinstance(value, str):
         return dp.parse(value).timestamp()
     elif isinstance(value, dt.datetime):


### PR DESCRIPTION
## Overview

This PR in collaboration with @EmersonDove  allows for much easier use of the `Blankly.Strategy` class. We've reimplemnted some abstractions using `@property` decorators and allowed for easier access to values including `cash` and wrapped functions with items such as `account`, `history` and `orders`.

## Newest Updates

### Updates to `history()`

This new PR implements history to allow for three primary types of data gathering:
1. Using `to` similar to `backtest` where it goes back in time by a specific time interval of type `str`

```python
a = Alpaca()
interface = a.interface
interface.history('MSFT', '1w', '1d') # means 1 week worth of 1 day resolution BTCUSD
```
2. Using `to` as the number of points in time expressed as an integer to allow for easier moving average calculations
```python
a = Alpaca()
interface = a.interface
interface.history('MSFT', 7, '1d') # means 7 days of 1 day resolution BTCUSD which is the same as above
```
3. Using `start_date` and `end_date` 
```python
a = Alpaca()
interface = a.interface
interface.history('MSFT', resolution='1d', start_date='2017-05-02', end_date='2020-05-02') 
```

