### PR TITLE
Update Scheduler to Run on Ceiled Time

### DIFF
--- a/blankly/exchanges/interfaces/abc_exchange_interface.py
+++ b/blankly/exchanges/interfaces/abc_exchange_interface.py
@@ -195,19 +195,21 @@ class ABCExchangeInterface(abc.ABC):
     @abc.abstractmethod
     def history(self, 
                 symbol: str, 
-                to: Union[str, int]=200, 
-                resolution: str='1d', 
-                start_date: Union[str, datetime, float]=None, 
-                end_date: Union[str, datetime, float]=None) -> pandas.DataFrame:
+                to: Union[str, int] = 200,
+                resolution: str = '1d',
+                start_date: Union[str, datetime, float] = None,
+                end_date: Union[str, datetime, float] = None) -> pandas.DataFrame:
         """
         Wrapper for .get_product_history() which allows users to more easily get product history from right now.
         Args:
-            product_id: Blankly product ID format (BTC-USD)
-            to (str or int): The number of data points back in time either expressed as a string ("1y" meaning 1 year back") 
-                or int of points (300 points at specified resolution)
+            symbol: Blankly product ID format (BTC-USD)
+            to (str or int): The number of data points back in time either expressed as a string
+                ("1y" meaning 1 year back") or int of points (300 points at specified resolution)
             resolution: Resolution as a string (i.e. "1d", "4h", "1y")
-            start_date (str or datetime or float): Start Date for data gathering (in either string, datetime or epoch timestamp)
-            end_date (str or datetime or float): End Date for data gathering (in either string, datetime or epoch timestamp)
+            start_date (str or datetime or float): Start Date for data gathering (in either string, datetime or epoch
+                timestamp)
+            end_date (str or datetime or float): End Date for data gathering (in either string, datetime or epoch
+                timestamp)
         Returns:
             Dataframe with *at least* 'time (epoch)', 'low', 'high', 'open', 'close', 'volume' as columns.
             TODO add return example

--- a/blankly/exchanges/interfaces/alpaca/alpaca_interface.py
+++ b/blankly/exchanges/interfaces/alpaca/alpaca_interface.py
@@ -227,6 +227,12 @@ class AlpacaInterface(ExchangeInterface):
         if found_multiple < 0:
             raise ValueError("alpaca currently does not support this specific resolution, please make the resolution a multiple of 1 minute, 1 hour or 1 day")
         
+        row_divisor = resolution // multiple
+
+        if row_divisor > 100:
+            raise Warning("The resolution you requested is an extremely high of the base resolutions supported and may slow down the performance of your model: {} * {}"
+                .format(found_multiple, row_divisor))
+
         if found_multiple == 60:
             time_interval = TimeFrame.Minute
         elif found_multiple == 3600:
@@ -234,7 +240,6 @@ class AlpacaInterface(ExchangeInterface):
         else:
             time_interval = TimeFrame.Day
 
-        row_divisor = resolution // multiple
 
         epoch_start_str = epoch_start.isoformat()
         epoch_stop_str = epoch_stop.isoformat()

--- a/blankly/exchanges/interfaces/alpaca/alpaca_interface.py
+++ b/blankly/exchanges/interfaces/alpaca/alpaca_interface.py
@@ -180,6 +180,7 @@ class AlpacaInterface(ExchangeInterface):
         for order in orders:
             order = utils.rename_to(renames, order)
             needed = self.choose_order_specificity(order['type'])
+            order['created_at'] = parser.isoparse(order['created_at']).timestamp()
             order = utils.isolate_specific(needed, order)
         return orders
 
@@ -219,7 +220,7 @@ class AlpacaInterface(ExchangeInterface):
             raise ValueError("alpaca does not support sub-minute candlesticks")
         
         found_multiple = -1
-        for multiple in supported_multiples:
+        for multiple in reversed(supported_multiples):
             if resolution % multiple == 0:
                 found_multiple = multiple
                 break

--- a/blankly/exchanges/interfaces/alpaca/alpaca_websocket.py
+++ b/blankly/exchanges/interfaces/alpaca/alpaca_websocket.py
@@ -35,6 +35,7 @@ class Tickers(ABCExchangeWebsocket):
             symbol: Currency to initialize on such as "btcusdt"
             stream: Stream to use, such as "depth" or "trade"
             log: Fill this with a path to a log file that should be created
+            initially_stopped: Keep the websocket closed when the websocket is created
             WEBSOCKET_URL: Default websocket URL feed.
         """
         self.__id = symbol

--- a/blankly/exchanges/interfaces/exchange_interface.py
+++ b/blankly/exchanges/interfaces/exchange_interface.py
@@ -166,19 +166,19 @@ class ExchangeInterface(ABCExchangeInterface, abc.ABC):
         using_setting = self.user_preferences['settings'][self.exchange_name]['cash']
         return self.get_account(using_setting)['available']
 
-    def history(self, symbol: str, to=200, resolution: str='1d', start_date=None, end_date=None):
+    def history(self, symbol: str, to=200, resolution: str = '1d', start_date=None, end_date=None):
         if end_date is None:
             epoch_stop = time.time()
         else:
             epoch_stop = utils.convert_input_to_epoch(end_date)
 
-        # convert resolution into epoch seconds    
+        # convert resolution into epoch seconds
         resolution_seconds = time_interval_to_seconds(resolution)
 
         if start_date is None:
-            if isinstance(to, int):
+            if isinstance(to, int) or isinstance(to, float):
                 # use number of points to calculate the start epoch
-                epoch_start = epoch_stop - to * resolution_seconds
+                epoch_start = epoch_stop - ((to+1) * resolution_seconds)
             else:
                 epoch_start = epoch_stop - time_interval_to_seconds(to)
         else:

--- a/blankly/exchanges/interfaces/paper_trade/paper_trade_interface.py
+++ b/blankly/exchanges/interfaces/paper_trade/paper_trade_interface.py
@@ -277,10 +277,8 @@ class PaperTradeInterface(ExchangeInterface, BacktestingWrapper):
         price = self.get_price(symbol)
 
         market_limits = self.get_asset_limits(symbol)
-        if "min_market_funds" in market_limits['exchange_specific']:
-            min_funds = float(market_limits["exchange_specific"]["min_market_funds"])
-        else:
-            min_funds = float(market_limits["base_min_size"]) * price
+
+        min_funds = float(market_limits["min_market_funds"])
 
         if funds < min_funds:
             raise InvalidOrder("Invalid Order: funds is too small. Minimum is: " + str(min_funds))

--- a/blankly/strategy/strategy_base.py
+++ b/blankly/strategy/strategy_base.py
@@ -57,7 +57,7 @@ class Strategy:
         self.__variables[hashed][key] = value
 
     def add_price_event(self, callback: typing.Callable, symbol: str, resolution: str,
-                        init: typing.Callable = None, synced: bool = True, ohlc: bool = False, **kwargs):
+                        init: typing.Callable = None, synced: bool = False, ohlc: bool = False, **kwargs):
         """
         Add Price Event
         Args:
@@ -79,6 +79,8 @@ class Strategy:
         self.__variables[callback_hash] = AttributeDict({})
         state = StrategyState(self, self.__variables[callback_hash], resolution)
 
+        if ohlc:
+            synced = True
         # run init
         if init:
             init(symbol, state)

--- a/blankly/strategy/strategy_base.py
+++ b/blankly/strategy/strategy_base.py
@@ -128,7 +128,7 @@ class Strategy:
         state.resolution = resolution
 
         if ohlc:
-            data = self.Interface.history(symbol, 1, resolution).to_dict()
+            data = self.Interface.history(symbol, 1, resolution).iloc[0].to_dict()
             data['price'] = self.Interface.get_price(symbol)
         else:
             data = self.Interface.get_price(symbol)

--- a/blankly/strategy/strategy_base.py
+++ b/blankly/strategy/strategy_base.py
@@ -295,7 +295,7 @@ class Strategy:
         for i in self.__schedulers:
             kwargs = i.get_kwargs()
             backtesting_controller.append_backtest_price_event(callback=kwargs['callback'],
-                                                               asset_id=kwargs['currency_pair'],
+                                                               asset_id=kwargs['symbol'],
                                                                time_interval=i.get_interval(),
                                                                state_object=kwargs['state_object']
                                                                )

--- a/blankly/strategy/strategy_usage_example.py
+++ b/blankly/strategy/strategy_usage_example.py
@@ -47,9 +47,9 @@ if __name__ == "__main__":
     coinbase_strategy = Strategy(coinbase_pro)
     alpaca_strategy = Strategy(alpaca)
 
-    coinbase_strategy.add_price_event(golden_cross, currency_pair='BTC-USD', resolution='15m')
-    coinbase_strategy.add_price_event(rsi, currency_pair='XLM-USD', resolution='15m')
+    coinbase_strategy.add_price_event(golden_cross, symbol='BTC-USD', resolution='15m')
+    coinbase_strategy.add_price_event(rsi, symbol='XLM-USD', resolution='15m')
 
-    alpaca_strategy.add_price_event(golden_cross, currency_pair='MSFT', resolution='15m')
-    alpaca_strategy.add_price_event(rsi, currency_pair='AAPL', resolution='15m')
+    alpaca_strategy.add_price_event(golden_cross, symbol='MSFT', resolution='15m')
+    alpaca_strategy.add_price_event(rsi, symbol='AAPL', resolution='15m')
     

--- a/blankly/utils/scheduler.py
+++ b/blankly/utils/scheduler.py
@@ -26,7 +26,7 @@ import traceback
 
 
 class Scheduler:
-    def __init__(self, function, interval, initially_stopped=False, **kwargs):
+    def __init__(self, function, interval, initially_stopped=False, synced=True, **kwargs):
         """
         Wrapper for functions that run at a set interval
         Args:
@@ -40,6 +40,7 @@ class Scheduler:
         # Stop flag
         self.__stop = False
         self.__thread = None
+        self.synced = synced
 
         self.__interval = interval
         self.__kwargs = kwargs
@@ -101,9 +102,11 @@ class Scheduler:
         """
         This function is used with the scheduler decorator
         """
-        base_time = ceil_date(datetime.now(), seconds=interval).timestamp()
-        offset = base_time - time.time()
-        time.sleep(offset)
+        base_time = time.time()
+        if self.synced:
+            base_time = ceil_date(datetime.now(), seconds=interval).timestamp()
+            offset = base_time - time.time()
+            time.sleep(offset)
         while True:
             if self.__stop:
                 break

--- a/blankly/utils/scheduler.py
+++ b/blankly/utils/scheduler.py
@@ -107,17 +107,16 @@ class Scheduler:
             base_time = ceil_date(datetime.now(), seconds=interval).timestamp()
             offset = base_time - time.time()
             time.sleep(offset)
+            kwargs['ohlcv_time'] = base_time
         while True:
             if self.__stop:
                 break
             try:
-                if kwargs == {}:
-                    func()
-                else:
-                    func(**kwargs)
+                func(**kwargs)
             except Exception:
                 traceback.print_exc()
             base_time += interval
+            kwargs['ohlcv_time'] += interval
 
             # The downside of this is that it keeps the thread running while waiting to stop
             # It's dependent on delay if its more efficient to just check more

--- a/blankly/utils/scheduler.py
+++ b/blankly/utils/scheduler.py
@@ -18,6 +18,8 @@
 import warnings
 
 from blankly.utils.time_builder import time_interval_to_seconds
+from blankly.utils import ceil_date
+from datetime import datetime
 import threading
 import time
 import traceback
@@ -99,7 +101,9 @@ class Scheduler:
         """
         This function is used with the scheduler decorator
         """
-        base_time = time.time()
+        base_time = ceil_date(datetime.now(), seconds=interval).timestamp()
+        offset = base_time - time.time()
+        time.sleep(offset)
         while True:
             if self.__stop:
                 break
@@ -110,7 +114,7 @@ class Scheduler:
                     func(**kwargs)
             except Exception:
                 traceback.print_exc()
-            base_time = base_time + interval
+            base_time += interval
 
             # The downside of this is that it keeps the thread running while waiting to stop
             # It's dependent on delay if its more efficient to just check more

--- a/blankly/utils/scheduler.py
+++ b/blankly/utils/scheduler.py
@@ -18,7 +18,7 @@
 import warnings
 
 from blankly.utils.time_builder import time_interval_to_seconds
-from blankly.utils import ceil_date
+from blankly.utils.utils import ceil_date
 from datetime import datetime
 import threading
 import time

--- a/blankly/utils/utils.py
+++ b/blankly/utils/utils.py
@@ -468,8 +468,8 @@ def get_ohlcv(candles, n):
     new_candles['volume'] = sum_period(candles['volume'].astype(float), n, True)
     new_candles['close'] = candles['close'].iloc[::n].reset_index(drop=True)
     new_candles['open'] = candles['open'].iloc[::n].reset_index(drop=True)
-    new_candles['timestamp'] = candles.index.to_series().iloc[::n].reset_index(drop=True)
-    return new_candles.set_index('timestamp')
+    new_candles['time'] = candles.index.to_series().iloc[::n].reset_index(drop=True)
+    return new_candles.set_index('time')
 
 def ceil_date(date, **kwargs):
     secs = dt.timedelta(**kwargs).total_seconds()

--- a/blankly/utils/utils.py
+++ b/blankly/utils/utils.py
@@ -471,6 +471,10 @@ def get_ohlcv(candles, n):
     new_candles['timestamp'] = candles.index.to_series().iloc[::n].reset_index(drop=True)
     return new_candles.set_index('timestamp')
 
+def ceil_date(date, **kwargs):
+    secs = dt.timedelta(**kwargs).total_seconds()
+    return dt.datetime.fromtimestamp(date.timestamp() + secs - date.timestamp() % secs)
+
 class AttributeDict(dict):
     def __getattr__(self, attr):
         return self[attr]

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -19,9 +19,9 @@ if __name__ == "__main__":
     coinbase_strategy = blankly.Strategy(coinbase_pro)
 
     # Run the price event function every time we check for a new price - by default that is 15 seconds
-    coinbase_strategy.add_price_event(price_event, currency_pair='BTC-USD', resolution='15s')
-    coinbase_strategy.add_price_event(price_event, currency_pair='LINK-USD', resolution='15s')
-    coinbase_strategy.add_price_event(price_event, currency_pair='ETH-BTC', resolution='15s')
+    coinbase_strategy.add_price_event(price_event, symbol='BTC-USD', resolution='15s')
+    coinbase_strategy.add_price_event(price_event, symbol='LINK-USD', resolution='15s')
+    coinbase_strategy.add_price_event(price_event, symbol='ETH-BTC', resolution='15s')
 
     # Start the strategy. This will begin each of the price event ticks
     coinbase_strategy.start()


### PR DESCRIPTION
## Overview

This introduces an additional function that utilizes `datetime` and `timedelta` to calculate the nearest ceiled time for a given interval of seconds passed into the scheduler. More information on this can be found [here](https://stackoverflow.com/questions/32723150/rounding-up-to-nearest-30-minutes-in-python/50268328). 

This also introduces `add_bar_event` which allows users to utilize OHLCV data as a mechanism. This is particularly useful for some of the indicators including the `aroon_oscillator`

## Syncing Scheduler

Now, utilizing a `self.sync` parameter, users are able to directly sync with the nearest "whole" minute that will align with with the exchange (f.e., if users start their model at 12:12 and they want to be run on a `5m` interval, the model will be run at 12:15).

Users can now define this in a price event by doing this:

```python
def price_event(price, symbol, state):
     ...

a = Alpaca()
s = Strategy(a)
s.add_price_event(price_event, sync=True, resolution='15m') # will sync with xx:15, xx:30, xx:45, xx:00 
```

## OHLCV Data

New work has been done to allow for multiples of the various granularities found for `Alpaca` that allows users to get `barset` data that is in between intervals (i.e. 5m, 5h, etc.) 

## `add_bar_event`

Users may want to add a bar event to get OHLCV data, this is now done like so: 

```python
def price_event(data, symbol, state):
    open = data['open'] # 'close', 'volume', 'low', 'high'
     ...

a = Alpaca()
s = Strategy(a)
s.add_bar_event(price_event, resolution='15m') # default synced with the market exchange
```