### PR TITLE
Added variable resolution and risk free rate to the back-test metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@
 <p align="center">
     <a target="_blank" href="https://docs.blankly.finance">View Docs</a>
     ·
-    <a href="https://blankly.finance">Our Website</a>
+    <a target="_blank" href="https://blankly.finance">Our Website</a>
+    ·
+    <a target="_blank" href="https://blankly.substack.com">Join Our Newsletter</a>
     ·
     <a href="#quickstart">Getting Started</a>
   </p>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
    <a target="_blank" href="https://github.com/Blankly-Finance/Blankly/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/blankly?color=gree"></a>
    <a target="_blank" href="https://github.com/Blankly-Finance/Blankly/stargazers"><img src="https://img.shields.io/github/stars/blankly-finance/blankly?style=social"></a>
    <a target="_blank" href="https://discord.gg/XWcmy7Y9bb"><img src="https://img.shields.io/discord/821563936297451530.svg?color=7289da&label=Blankly%20Discord&logo=discord&style=flat"></a>
+   <a target="_blank" href="https://reddit.com/r/blankly"><img src="https://badgen.net/reddit/subscribers/r/blankly"></a>
 </p>
 <p align="center">
     <a target="_blank" href="https://docs.blankly.finance">View Docs</a>

--- a/blankly/exchanges/interfaces/paper_trade/backtest_controller.py
+++ b/blankly/exchanges/interfaces/paper_trade/backtest_controller.py
@@ -836,6 +836,9 @@ class BackTestController:
             # Find the interval second value
             interval_value = time_interval_to_seconds(resample_setting)
 
+            # Add the internval value to dictionary
+            dataframes['trading_period'] = interval_value
+
             # Assign start and stop limits
             epoch_start = epoch_backup[0]
             epoch_max = epoch_backup[len(epoch_backup) - 1]
@@ -873,6 +876,9 @@ class BackTestController:
 
             # Now write it to our dictionary
             dataframes['returns'] = returns
+
+            # Add risk-free-return rate to dictionary
+            dataframes['risk_free_return_rate'] = self.preferences['settings'].get("risk_free_return_rate", 0.0)
 
             # -----=====*****=====----- I thought I stopped doing these comments when I actually learned to code
             metrics_indicators['Compound Annual Growth Rate (%)'] = metrics.cagr(dataframes)

--- a/blankly/exchanges/interfaces/paper_trade/metrics.py
+++ b/blankly/exchanges/interfaces/paper_trade/metrics.py
@@ -20,6 +20,23 @@ import blankly.metrics as metrics
 from blankly.utils.time_builder import build_year
 
 
+def periods_per_year(period : int) -> float:
+    """
+    Find how many trading periods occur within a trading year
+
+    Args:
+        period: the number of seconds in each trading period
+    Returns:
+        number of trading periods in each year
+        
+    """
+    # TODO: update logic to account for strategies that do not hold overnight
+    # 24 hours becomes 6.5 (hours the market is open) AND the risk_free_rate
+    # goes to zero
+    trading_seconds_per_year = 252.0 * 24.0 * 60.0 * 60.0
+    ppy = trading_seconds_per_year/period
+    return ppy
+
 def cagr(backtest_data):
     account_values = backtest_data['resampled_account_value']
     years = (account_values['time'].iloc[-1] - account_values['time'].iloc[0]) / build_year()
@@ -32,24 +49,23 @@ def cum_returns(backtest_data):
 
 
 def sortino(backtest_data):
-    # TODO: Need to pass in the specific resolution
-    # Defaulting to 1d
     returns = backtest_data['returns']['value']
-    return round(metrics.sortino(returns), 2)
+    risk_free_rate = backtest_data['risk_free_return_rate']
+    ppy = periods_per_year(backtest_data['trading_period'])
+    return round(metrics.sortino(returns, ppy, risk_free_rate), 2)
 
 
 def sharpe(backtest_data):
-    # TODO: Need to pass in the specific resolution
-    # Defaulting to 1d
     returns = backtest_data['returns']['value']
-    return round(metrics.sharpe(returns), 2)
+    risk_free_rate = backtest_data['risk_free_return_rate']
+    ppy = periods_per_year(backtest_data['trading_period'])
+    return round(metrics.sharpe(returns, ppy, risk_free_rate), 2)
 
 
 def calmar(backtest_data):
-    # TODO: Need to pass in the specific resolution
-    # Defaulting to 1d
     returns = backtest_data['returns']['value']
-    return round(metrics.calmar(returns), 2)
+    ppy = periods_per_year(backtest_data['trading_period'])
+    return round(metrics.calmar(returns, ppy), 2)
 
 
 def volatility(backtest_data):

--- a/blankly/frameworks/strategy/strategy_base.py
+++ b/blankly/frameworks/strategy/strategy_base.py
@@ -422,10 +422,13 @@ class Strategy:
                         Multiple types of quote currency (ex: USD and EUR) are not supported because
                         there is no datasource for quoting pairs such as EUR-USD until forex integration.
 
-                ignore_user_exceptions: bool = False
+                ignore_user_exceptions: bool = True
                     Set this to True to handle user exceptions identically to how they're handled by strategy calls.
                         False means that the backtest will immediately stop & attempt to generate a report if something
                         in the user calls goes wrong. True will replicate strategy errors.
+
+                ignore_user_exceptions: float = 0.0
+                    Set this to be the theoretical rate of return with no risk
         """
 
         start = None

--- a/blankly/utils/utils.py
+++ b/blankly/utils/utils.py
@@ -71,7 +71,8 @@ default_backtest_settings = {
         "continuous_caching": True,
         "resample_account_value_for_metrics": "1d",
         "quote_account_value_in": "USD",
-        "ignore_user_exceptions": False
+        "ignore_user_exceptions": False,
+        "risk_free_return_rate" : 0.0
     }
 }
 

--- a/examples/backtest.json
+++ b/examples/backtest.json
@@ -13,6 +13,7 @@
     "continuous_caching": true,
     "resample_account_value_for_metrics": "1d",
     "quote_account_value_in": "USD",
-    "ignore_user_exceptions": true
+    "ignore_user_exceptions": true,
+    "risk_free_return_rate": 0.0
   }
 }


### PR DESCRIPTION
Adds variable trading-period capability to the calculation of the metrics. The value is driven off the "resample_account_value_for_metrics" property in the backtest.json file.  

Also added "risk_free_return_rate" to the file so the user can specify their value. Added the value into the defaults to ensure error checking.

left a TODO in regards to changing the values when strategies are setup to close all positions over night; not quite ready to tackle this myself yet.