### PR TITLE
Allow backtesting to follow historical data

### DIFF
--- a/blankly/exchanges/interfaces/binance/binance_interface.py
+++ b/blankly/exchanges/interfaces/binance/binance_interface.py
@@ -797,6 +797,9 @@ class BinanceInterface(ExchangeInterface):
 
                 "min_price": min_price,
                 "max_price": max_price,
+
+                "hard_min_price": hard_min_price,
+                "hard_max_price": hard_max_price,
             },
             'market_order': {
                 "fractionable": True,

--- a/blankly/exchanges/interfaces/paper_trade/paper_trade_interface.py
+++ b/blankly/exchanges/interfaces/paper_trade/paper_trade_interface.py
@@ -504,8 +504,8 @@ class PaperTradeInterface(ExchangeInterface, BacktestingWrapper):
         if size > max_base:
             raise InvalidOrder("Order quantity is too large. Maximum is: " + str(max_base))
 
-        min_price = float(order_filter['limit_order']["min_price"])
-        max_price = float(order_filter['limit_order']["max_price"])
+        min_price = float(order_filter['limit_order']["hard_min_price"])
+        max_price = float(order_filter['limit_order']["hard_max_price"])
 
         if price < min_price:
             raise InvalidOrder("Limit price is too small. Minimum is: " + str(min_price))


### PR DESCRIPTION
Binance recommends a +/- 25% check for limit prices. This limitation uses the *current* price and does not apply when running backtesting over a long period of time where the initial price is outside the +/-25% range. 
Instead of testing against the suggested binance range, this tests against the absolute min/max provided by binance.
 *** This might also need to be implemented for the other exchanges.