### PR TITLE
FTX tld support

### DIFF
--- a/blankly/exchanges/interfaces/ftx/ftx.py
+++ b/blankly/exchanges/interfaces/ftx/ftx.py
@@ -35,7 +35,8 @@ class FTX(Exchange):
         keys = auth.keys
         sandbox = super().evaluate_sandbox(auth)
 
-        calls = FTXAPI(keys['API_KEY'], keys['API_SECRET'])
+        calls = FTXAPI(keys['API_KEY'], keys['API_SECRET'],
+                       tld=self.preferences["settings"]["ftx"]["ftx_tld"])
 
         # Always finish the method with this function
         super().construct_interface_and_cache(calls)

--- a/blankly/utils/utils.py
+++ b/blankly/utils/utils.py
@@ -50,7 +50,8 @@ default_general_settings = {
             "cash": "USDT"
         },
         "ftx": {
-            "cash": "USD"
+            "cash": "USD",
+            "ftx_tld": "us"
         },
         "alpaca": {
             "websocket_stream": "iex",

--- a/examples/settings.json
+++ b/examples/settings.json
@@ -3,7 +3,6 @@
     "use_sandbox_websockets": false,
     "websocket_buffer_size": 10000,
     "test_connectivity_on_auth": true,
-
     "coinbase_pro": {
       "cash": "USD"
     },
@@ -27,7 +26,8 @@
       "cash": "USDT"
     },
     "ftx": {
-      "cash": "USD"
+      "cash": "USD",
+      "ftx_tld": "us"
     }
   }
 }


### PR DESCRIPTION
This PR adds support for the `ftx_tld` key in settings.json.

- Requests to the "com" tld will be routed to `https://ftx.com/api`
- Requests to any other tld than "us" will have "FTX" instead of "FTXUS" headers. (FTX-KEY instead of FTXUS-KEY for example)