### PR TITLE
make cli easier to run for users without pip scripts on PATH

### DIFF
--- a/blankly/__init__.py
+++ b/blankly/__init__.py
@@ -43,12 +43,13 @@ from blankly.utils.scheduler import Scheduler
 import blankly.indicators as indicators
 from blankly.utils import time_builder
 
+import blankly.deployment.new_cli
+
 from blankly.enums import Side, OrderType, OrderStatus, TimeInForce
 
 from blankly.deployment.reporter_headers import Reporter as __Reporter_Headers
 is_deployed = False
 _screener_runner = None
-
 
 
 _backtesting = blankly.utils.check_backtesting()

--- a/blankly/__main__.py
+++ b/blankly/__main__.py
@@ -1,0 +1,4 @@
+import blankly.deployment.new_cli
+
+if __name__ == '__main__':
+    blankly.deployment.new_cli.main()

--- a/blankly/deployment/new_cli.py
+++ b/blankly/deployment/new_cli.py
@@ -486,7 +486,7 @@ def blankly_key(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Blankly CLI & deployment tool')
+    parser = argparse.ArgumentParser(prog='blankly', description='Blankly CLI & deployment tool')
     subparsers = parser.add_subparsers(required=True)
 
     init_parser = subparsers.add_parser('init', help='Initialize a new model in the current directory')


### PR DESCRIPTION
this change will let users do `python -m blankly` instead of `blankly` to run the cli.

this is helpful when `python` is on `$PATH` but `blankly` is not.
