### PR TITLE
Added functionality to send to a Google Chat Space (via webhook)

### DIFF
--- a/blankly/deployment/reporter_headers.py
+++ b/blankly/deployment/reporter_headers.py
@@ -188,3 +188,40 @@ class Reporter:
             email: The body of the email to send
         """
         self.__send_email(email)
+        
+    def chat(self, message: str):
+        """
+        Sends a text message to a Google Chat Space through a webhook_url
+        Create the webhook following these instructions:
+            https://developers.google.com/chat/how-tos/webhooks#register_the_incoming_webhook
+            Register the incoming webhook
+            1. In a browser, open Chat. Webhooks aren't configurable from the Chat mobile app.
+            2. Go to the space where you want to add a webhook.
+            3. Next to the space title, click the expand more arrow, and then click Apps & integrations.
+            4. Click Add webhooks.
+            5. In the Name field, enter a name for your webhook (such as "Blankly Notifications").
+            6. In the Avatar URL field, enter a URL to an icon (such as https://blankly.finance/_nuxt/img/blankly-black.c8ffff6.svg).
+            7. Click Save.
+            8. To copy the webhook URL, click more_vert More, and then click Copy link.
+        Args:
+            message: The text of the message to send to the webhook_url specified in notify.json
+        """
+        # https://github.com/googleworkspace/google-chat-samples/blob/main/python/webhook/quickstart.py
+        from json import dumps
+        from httplib2 import Http
+
+        try:
+            notify_preferences = load_notify_preferences()
+            webhook = notify_preferences['chat']['webhook_url']
+
+            app_message = {"text": message}
+            message_headers = {"Content-Type": "application/json; charset=UTF-8"}
+            http_obj = Http()
+            response = http_obj.request(
+                uri=webhook,
+                method="POST",
+                headers=message_headers,
+                body=dumps(app_message),
+            )
+        except KeyError:
+            raise KeyError("Google Chat webhook URL not found. Check the notify.json documentation")

--- a/examples/notify_example.json
+++ b/examples/notify_example.json
@@ -9,5 +9,8 @@
   "text": {
     "phone_number": "1234567683",
     "provider": "verizon"
+  },
+  "chat": {
+    "webhook_url": "follow-instructions-here --> https://developers.google.com/chat/how-tos/webhooks#register_the_incoming_webhook"
   }
 }


### PR DESCRIPTION
I'm not very proficient at contributing to other people's guthub repos, so let me know if this there's a better/more standard way to contribute code.

Added chat() function to reporter_headers.py to allow sending chat messages to a Google Chat Space when a webhook_url is provided in the notify.json file.  examples/notify_example.json has an example of what that config looks like and a link to Google's instructions on how to create the webhook URL in the Chat Space.

Example usage:
```
if not backtest:
    blankly.reporter.chat(f'Starting script at {datetime.now()}')
```

