### PR TITLE
Add FXMacroData price and macro event readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ if __name__ == "__main__":
 
 ```
 
+Daily FX spot data from FXMacroData can be used anywhere Blankly accepts a
+custom `PriceReader`:
+
+```python
+reader = blankly.data.FXMacroDataPriceReader('EUR/USD', '2024-01-01', '2024-03-01')
+exchange = blankly.KeylessExchange(price_reader=reader, initial_account_values={'USD': 10000})
+```
+
 **Check out alternative data examples [here](https://docs.blankly.finance/examples/model-framework)**
 
 #### Accurate Backtest Holdings

--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ reader = blankly.data.FXMacroDataPriceReader('EUR/USD', '2024-01-01', '2024-03-0
 exchange = blankly.KeylessExchange(price_reader=reader, initial_account_values={'USD': 10000})
 ```
 
+FXMacroData also exposes macroeconomic announcement events, release calendars,
+and forecast groups for event-driven research:
+
+```python
+events = blankly.data.FXMacroDataAnnouncementReader('USD', 'inflation')
+calendar = blankly.data.FXMacroDataCalendarReader('USD', indicator='policy_rate')
+forecasts = blankly.data.FXMacroDataPredictionReader('USD', 'non_farm_payrolls')
+```
+
 **Check out alternative data examples [here](https://docs.blankly.finance/examples/model-framework)**
 
 #### Accurate Backtest Holdings

--- a/blankly/data/__init__.py
+++ b/blankly/data/__init__.py
@@ -17,6 +17,7 @@
 """
 
 from blankly.data.data_reader import PriceReader, JsonEventReader, TickReader, DataTypes
+from blankly.data.fxmacrodata import FXMacroDataPriceReader
 
 """
 Some datatype examples

--- a/blankly/data/__init__.py
+++ b/blankly/data/__init__.py
@@ -17,7 +17,13 @@
 """
 
 from blankly.data.data_reader import PriceReader, JsonEventReader, TickReader, DataTypes
-from blankly.data.fxmacrodata import FXMacroDataPriceReader
+from blankly.data.fxmacrodata import (
+    FXMacroDataAnnouncementReader,
+    FXMacroDataCalendarReader,
+    FXMacroDataClient,
+    FXMacroDataPredictionReader,
+    FXMacroDataPriceReader,
+)
 
 """
 Some datatype examples

--- a/blankly/data/fxmacrodata.py
+++ b/blankly/data/fxmacrodata.py
@@ -17,17 +17,89 @@
 """
 
 import os
-from typing import Optional
-from typing import Tuple
+from typing import Optional, Tuple
 
 import pandas as pd
 import requests
 
-from blankly.data.data_reader import PriceReader
+from blankly.data.data_reader import DataReader, DataTypes, PriceReader
 
 DEFAULT_BASE_URL = "https://fxmacrodata.com/api/v1"
 API_KEY_ENV_VARS = ("FXMACRODATA_API_KEY", "FXMD_API_KEY")
 PRICE_COLUMNS = ["time", "open", "high", "low", "close", "volume"]
+
+
+class FXMacroDataClient:
+    """Small REST client for FXMacroData's public API."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = 30,
+    ):
+        self.api_key = api_key or get_env_api_key()
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def get(self, path: str, params: Optional[dict] = None):
+        headers = {}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        response = requests.get(
+            f"{self.base_url}/{path.lstrip('/')}",
+            params=clean_params(params or {}),
+            headers=headers,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def forex(self, base: str, quote: str, start_date=None, end_date=None):
+        return self.get(
+            f"forex/{base.lower()}/{quote.lower()}",
+            {
+                "start_date": format_date(start_date) if start_date else None,
+                "end_date": format_date(end_date) if end_date else None,
+            },
+        )
+
+    def announcements(
+        self, currency: str, indicator: str, start_date=None, end_date=None, limit=None
+    ):
+        return self.get(
+            f"announcements/{currency.lower()}/{indicator.lower()}",
+            {
+                "start_date": format_date(start_date) if start_date else None,
+                "end_date": format_date(end_date) if end_date else None,
+                "limit": limit,
+            },
+        )
+
+    def calendar(self, currency: str, indicator: Optional[str] = None, start_date=None, end_date=None):
+        return self.get(
+            f"calendar/{currency.lower()}",
+            {
+                "indicator": indicator.lower() if indicator else None,
+                "start_date": format_date(start_date) if start_date else None,
+                "end_date": format_date(end_date) if end_date else None,
+            },
+        )
+
+    def predictions(self, currency: str, indicator: str, start_date=None, end_date=None):
+        return self.get(
+            f"predictions/{currency.lower()}/{indicator.lower()}",
+            {
+                "start_date": format_date(start_date) if start_date else None,
+                "end_date": format_date(end_date) if end_date else None,
+            },
+        )
+
+    def data_catalogue(self, currency: str, include_coverage: bool = True):
+        return self.get(
+            f"data_catalogue/{currency.lower()}",
+            {"include_coverage": str(include_coverage).lower()},
+        )
 
 
 class FXMacroDataPriceReader(PriceReader):
@@ -54,31 +126,15 @@ class FXMacroDataPriceReader(PriceReader):
         timeout: float = 30,
     ):
         self.symbol = self.normalize_symbol(symbol)
-        self.api_key = api_key or self.get_env_api_key()
-        self.base_url = base_url.rstrip("/")
-        self.timeout = timeout
+        self.client = FXMacroDataClient(api_key=api_key, base_url=base_url, timeout=timeout)
 
         data = self.fetch_prices(start_date, stop_date)
         super().__init__(data, self.symbol)
 
     def fetch_prices(self, start_date, stop_date) -> pd.DataFrame:
         base, quote = self.split_symbol(self.symbol)
-        params = {
-            "start_date": self.format_date(start_date),
-            "end_date": self.format_date(stop_date),
-        }
-        headers = {}
-        if self.api_key:
-            headers["X-API-Key"] = self.api_key
-
-        response = requests.get(
-            f"{self.base_url}/forex/{base}/{quote}",
-            params=params,
-            headers=headers,
-            timeout=self.timeout,
-        )
-        response.raise_for_status()
-        data = self.rows_to_dataframe(self.payload_rows(response.json()))
+        payload = self.client.forex(base, quote, start_date, stop_date)
+        data = self.rows_to_dataframe(payload_rows(payload))
         if data.empty:
             raise ValueError(f"FXMacroData returned no prices for {self.symbol}")
         return data
@@ -93,7 +149,7 @@ class FXMacroDataPriceReader(PriceReader):
                 continue
             records.append(
                 {
-                    "time": cls.to_epoch(date),
+                    "time": to_epoch(date),
                     "open": rate,
                     "high": rate,
                     "low": rate,
@@ -104,15 +160,6 @@ class FXMacroDataPriceReader(PriceReader):
         if not records:
             return pd.DataFrame(columns=PRICE_COLUMNS)
         return pd.DataFrame(records).drop_duplicates("time").sort_values("time")
-
-    @staticmethod
-    def payload_rows(payload) -> list:
-        if isinstance(payload, list):
-            return payload
-        if isinstance(payload, dict):
-            rows = payload.get("data", [])
-            return rows if isinstance(rows, list) else []
-        return []
 
     @staticmethod
     def extract_rate(row: dict) -> Optional[float]:
@@ -137,23 +184,122 @@ class FXMacroDataPriceReader(PriceReader):
         base, quote = symbol.split("-")
         return base.lower(), quote.lower()
 
-    @staticmethod
-    def get_env_api_key() -> Optional[str]:
-        for name in API_KEY_ENV_VARS:
-            api_key = os.getenv(name)
-            if api_key:
-                return api_key
+
+class FXMacroDataEventReader(DataReader):
+    """Base event reader for FXMacroData macro rows."""
+
+    def __init__(self, event_type: str, rows: list, time_field: str = "announcement_datetime"):
+        super().__init__(DataTypes.event_json)
+        times = []
+        events = []
+        for row in rows:
+            event_time = row_time(row, time_field)
+            if event_time is None:
+                continue
+            times.append(event_time)
+            events.append(row)
+        self._write_dataset({"time": times, "data": events}, event_type, ("time", "data"))
+        self._internal_dataset[event_type] = self._internal_dataset[event_type].sort_values("time")
+
+
+class FXMacroDataAnnouncementReader(FXMacroDataEventReader):
+    """Event reader for realized macroeconomic announcements."""
+
+    def __init__(
+        self,
+        currency: str,
+        indicator: str,
+        start_date=None,
+        stop_date=None,
+        limit: Optional[int] = None,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = 30,
+    ):
+        client = FXMacroDataClient(api_key=api_key, base_url=base_url, timeout=timeout)
+        rows = payload_rows(client.announcements(currency, indicator, start_date, stop_date, limit))
+        event_type = f"fxmacrodata_announcements_{currency.lower()}_{indicator.lower()}"
+        super().__init__(event_type, rows)
+
+
+class FXMacroDataCalendarReader(FXMacroDataEventReader):
+    """Event reader for upcoming official release-calendar rows."""
+
+    def __init__(
+        self,
+        currency: str,
+        indicator: Optional[str] = None,
+        start_date=None,
+        stop_date=None,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = 30,
+    ):
+        client = FXMacroDataClient(api_key=api_key, base_url=base_url, timeout=timeout)
+        rows = payload_rows(client.calendar(currency, indicator, start_date, stop_date))
+        indicator_suffix = f"_{indicator.lower()}" if indicator else ""
+        event_type = f"fxmacrodata_calendar_{currency.lower()}{indicator_suffix}"
+        super().__init__(event_type, rows)
+
+
+class FXMacroDataPredictionReader(FXMacroDataEventReader):
+    """Event reader for FXMacroData forecasts grouped by announcement."""
+
+    def __init__(
+        self,
+        currency: str,
+        indicator: str,
+        start_date=None,
+        stop_date=None,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = 30,
+    ):
+        client = FXMacroDataClient(api_key=api_key, base_url=base_url, timeout=timeout)
+        rows = payload_rows(client.predictions(currency, indicator, start_date, stop_date))
+        event_type = f"fxmacrodata_predictions_{currency.lower()}_{indicator.lower()}"
+        super().__init__(event_type, rows)
+
+
+def clean_params(params: dict) -> dict:
+    return {key: value for key, value in params.items() if value is not None}
+
+
+def payload_rows(payload) -> list:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        rows = payload.get("data", [])
+        return rows if isinstance(rows, list) else []
+    return []
+
+
+def row_time(row: dict, time_field: str = "announcement_datetime") -> Optional[int]:
+    value = row.get(time_field) or row.get("announcement_datetime")
+    if value is not None:
+        return int(value)
+    date = row.get("date") or row.get("timestamp")
+    if date is None:
         return None
+    return to_epoch(date)
 
-    @staticmethod
-    def format_date(value) -> str:
-        return pd.Timestamp(value).strftime("%Y-%m-%d")
 
-    @staticmethod
-    def to_epoch(value) -> int:
-        timestamp = pd.Timestamp(value)
-        if timestamp.tzinfo is None:
-            timestamp = timestamp.tz_localize("UTC")
-        else:
-            timestamp = timestamp.tz_convert("UTC")
-        return int(timestamp.timestamp())
+def get_env_api_key() -> Optional[str]:
+    for name in API_KEY_ENV_VARS:
+        api_key = os.getenv(name)
+        if api_key:
+            return api_key
+    return None
+
+
+def format_date(value) -> str:
+    return pd.Timestamp(value).strftime("%Y-%m-%d")
+
+
+def to_epoch(value) -> int:
+    timestamp = pd.Timestamp(value)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.tz_localize("UTC")
+    else:
+        timestamp = timestamp.tz_convert("UTC")
+    return int(timestamp.timestamp())

--- a/blankly/data/fxmacrodata.py
+++ b/blankly/data/fxmacrodata.py
@@ -1,0 +1,159 @@
+"""
+    FXMacroData price reader
+    Copyright (C) 2026  Blankly Contributors
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import os
+from typing import Optional
+from typing import Tuple
+
+import pandas as pd
+import requests
+
+from blankly.data.data_reader import PriceReader
+
+DEFAULT_BASE_URL = "https://fxmacrodata.com/api/v1"
+API_KEY_ENV_VARS = ("FXMACRODATA_API_KEY", "FXMD_API_KEY")
+PRICE_COLUMNS = ["time", "open", "high", "low", "close", "volume"]
+
+
+class FXMacroDataPriceReader(PriceReader):
+    """
+    PriceReader that loads daily FX spot rates from FXMacroData.
+
+    Args:
+        symbol: FX pair such as ``EURUSD``, ``EUR/USD``, or ``EUR-USD``.
+        start_date: Start date accepted by ``pandas.Timestamp``.
+        stop_date: Stop date accepted by ``pandas.Timestamp``.
+        api_key: Optional FXMacroData API key. If omitted, ``FXMACRODATA_API_KEY``
+            and ``FXMD_API_KEY`` environment variables are checked.
+        base_url: FXMacroData REST API base URL.
+        timeout: HTTP timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        symbol: str,
+        start_date,
+        stop_date,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = 30,
+    ):
+        self.symbol = self.normalize_symbol(symbol)
+        self.api_key = api_key or self.get_env_api_key()
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+        data = self.fetch_prices(start_date, stop_date)
+        super().__init__(data, self.symbol)
+
+    def fetch_prices(self, start_date, stop_date) -> pd.DataFrame:
+        base, quote = self.split_symbol(self.symbol)
+        params = {
+            "start_date": self.format_date(start_date),
+            "end_date": self.format_date(stop_date),
+        }
+        headers = {}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+
+        response = requests.get(
+            f"{self.base_url}/forex/{base}/{quote}",
+            params=params,
+            headers=headers,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        data = self.rows_to_dataframe(self.payload_rows(response.json()))
+        if data.empty:
+            raise ValueError(f"FXMacroData returned no prices for {self.symbol}")
+        return data
+
+    @classmethod
+    def rows_to_dataframe(cls, rows: list) -> pd.DataFrame:
+        records = []
+        for row in rows:
+            date = row.get("date") or row.get("timestamp")
+            rate = cls.extract_rate(row)
+            if date is None or rate is None:
+                continue
+            records.append(
+                {
+                    "time": cls.to_epoch(date),
+                    "open": rate,
+                    "high": rate,
+                    "low": rate,
+                    "close": rate,
+                    "volume": 0.0,
+                }
+            )
+        if not records:
+            return pd.DataFrame(columns=PRICE_COLUMNS)
+        return pd.DataFrame(records).drop_duplicates("time").sort_values("time")
+
+    @staticmethod
+    def payload_rows(payload) -> list:
+        if isinstance(payload, list):
+            return payload
+        if isinstance(payload, dict):
+            rows = payload.get("data", [])
+            return rows if isinstance(rows, list) else []
+        return []
+
+    @staticmethod
+    def extract_rate(row: dict) -> Optional[float]:
+        for key in ("val", "value", "close", "rate", "fx_rate"):
+            value = row.get(key)
+            if value is not None:
+                return float(value)
+        return None
+
+    @staticmethod
+    def normalize_symbol(symbol: str) -> str:
+        pair = symbol.strip().upper()
+        if pair.endswith("=X"):
+            pair = pair[:-2]
+        pair = pair.replace("/", "").replace("-", "").replace("_", "")
+        if len(pair) != 6 or not pair.isalpha():
+            raise ValueError("FXMacroData symbols must look like EURUSD or EUR-USD")
+        return f"{pair[:3]}-{pair[3:]}"
+
+    @staticmethod
+    def split_symbol(symbol: str) -> Tuple[str, str]:
+        base, quote = symbol.split("-")
+        return base.lower(), quote.lower()
+
+    @staticmethod
+    def get_env_api_key() -> Optional[str]:
+        for name in API_KEY_ENV_VARS:
+            api_key = os.getenv(name)
+            if api_key:
+                return api_key
+        return None
+
+    @staticmethod
+    def format_date(value) -> str:
+        return pd.Timestamp(value).strftime("%Y-%m-%d")
+
+    @staticmethod
+    def to_epoch(value) -> int:
+        timestamp = pd.Timestamp(value)
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.tz_localize("UTC")
+        else:
+            timestamp = timestamp.tz_convert("UTC")
+        return int(timestamp.timestamp())

--- a/blankly/data/fxmacrodata.py
+++ b/blankly/data/fxmacrodata.py
@@ -24,7 +24,7 @@ import requests
 
 from blankly.data.data_reader import DataReader, DataTypes, PriceReader
 
-DEFAULT_BASE_URL = "https://fxmacrodata.com/api/v1"
+DEFAULT_BASE_URL = "https://api.fxmacrodata.com/v1"
 API_KEY_ENV_VARS = ("FXMACRODATA_API_KEY", "FXMD_API_KEY")
 PRICE_COLUMNS = ["time", "open", "high", "low", "close", "volume"]
 

--- a/tests/data/test_fxmacrodata_price_reader.py
+++ b/tests/data/test_fxmacrodata_price_reader.py
@@ -1,0 +1,151 @@
+"""
+    Unit tests for FXMacroData price reader
+    Copyright (C) 2026  Blankly Contributors
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import unittest
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+
+API_KEY = "api_key"
+ROOT_DIR = Path(__file__).resolve().parents[2]
+
+
+def load_fxmacrodata_module():
+    blankly_module = types.ModuleType("blankly")
+    blankly_module.__path__ = [str(ROOT_DIR / "blankly")]
+    data_module = types.ModuleType("blankly.data")
+    data_module.__path__ = [str(ROOT_DIR / "blankly" / "data")]
+    utils_module = types.ModuleType("blankly.utils")
+    utils_module.convert_epochs = lambda value: value
+    exchanges_module = types.ModuleType("blankly.exchanges")
+    interfaces_module = types.ModuleType("blankly.exchanges.interfaces")
+    futures_module = types.ModuleType(
+        "blankly.exchanges.interfaces.futures_exchange_interface"
+    )
+
+    class FuturesExchangeInterface:
+        pass
+
+    futures_module.FuturesExchangeInterface = FuturesExchangeInterface
+    stubs = {
+        "blankly": blankly_module,
+        "blankly.data": data_module,
+        "blankly.utils": utils_module,
+        "blankly.exchanges": exchanges_module,
+        "blankly.exchanges.interfaces": interfaces_module,
+        "blankly.exchanges.interfaces.futures_exchange_interface": futures_module,
+    }
+    with patch.dict(sys.modules, stubs):
+        data_reader_path = ROOT_DIR / "blankly" / "data" / "data_reader.py"
+        data_reader_spec = importlib.util.spec_from_file_location(
+            "blankly.data.data_reader", data_reader_path
+        )
+        data_reader = importlib.util.module_from_spec(data_reader_spec)
+        sys.modules["blankly.data.data_reader"] = data_reader
+        data_reader_spec.loader.exec_module(data_reader)
+
+        fxmacrodata_path = ROOT_DIR / "blankly" / "data" / "fxmacrodata.py"
+        fxmacrodata_spec = importlib.util.spec_from_file_location(
+            "blankly.data.fxmacrodata", fxmacrodata_path
+        )
+        fxmacrodata = importlib.util.module_from_spec(fxmacrodata_spec)
+        fxmacrodata_spec.loader.exec_module(fxmacrodata)
+    return fxmacrodata
+
+
+class FXMacroDataResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+class FXMacroDataPriceReaderTest(unittest.TestCase):
+    def setUp(self):
+        self.fxmacrodata = load_fxmacrodata_module()
+        self.price_reader_class = self.fxmacrodata.FXMacroDataPriceReader
+
+    def test_fetches_daily_fx_prices(self):
+        requests = []
+
+        def mock_get(url, params, headers, timeout):
+            requests.append((url, params, headers, timeout))
+            return FXMacroDataResponse(
+                {
+                    "data": [
+                        {"date": "2024-01-02", "val": "1.101"},
+                        {"date": "2024-01-03", "value": 1.102},
+                        {"date": "2024-01-04", "close": 1.103},
+                    ]
+                }
+            )
+
+        with patch.object(self.fxmacrodata.requests, "get", side_effect=mock_get):
+            reader = self.price_reader_class(
+                "EUR/USD",
+                "2024-01-02",
+                "2024-01-04",
+                api_key=API_KEY,
+                base_url="https://example.com/api/v1",
+            )
+
+        url, params, headers, timeout = requests[0]
+        self.assertEqual(url, "https://example.com/api/v1/forex/eur/usd")
+        self.assertEqual(
+            params, {"start_date": "2024-01-02", "end_date": "2024-01-04"}
+        )
+        self.assertEqual(headers, {"X-API-Key": API_KEY})
+        self.assertEqual(timeout, 30)
+        self.assertEqual(list(reader.data), ["EUR-USD"])
+        data = reader.data["EUR-USD"]
+        self.assertEqual(data["close"].tolist(), [1.101, 1.102, 1.103])
+        self.assertEqual(data["volume"].tolist(), [0.0, 0.0, 0.0])
+        self.assertEqual(reader.prices_info["EUR-USD"]["resolution"], 86400)
+
+    def test_symbol_formats(self):
+        self.assertEqual(self.price_reader_class.normalize_symbol("EURUSD"), "EUR-USD")
+        self.assertEqual(self.price_reader_class.normalize_symbol("EUR/USD"), "EUR-USD")
+        self.assertEqual(self.price_reader_class.normalize_symbol("EUR_USD"), "EUR-USD")
+        self.assertEqual(self.price_reader_class.normalize_symbol("EURUSD=X"), "EUR-USD")
+
+    def test_rows_to_dataframe_sorts_and_shapes_prices(self):
+        data = self.price_reader_class.rows_to_dataframe(
+            [
+                {"date": "2024-01-03", "val": 1.102},
+                {"date": "2024-01-02", "value": "1.101"},
+            ]
+        )
+
+        self.assertEqual(data["close"].tolist(), [1.101, 1.102])
+        self.assertEqual(data["open"].tolist(), [1.101, 1.102])
+        self.assertEqual(data["high"].tolist(), [1.101, 1.102])
+        self.assertEqual(data["low"].tolist(), [1.101, 1.102])
+        self.assertEqual(data["volume"].tolist(), [0.0, 0.0])
+        self.assertTrue(pd.api.types.is_integer_dtype(data["time"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/data/test_fxmacrodata_price_reader.py
+++ b/tests/data/test_fxmacrodata_price_reader.py
@@ -147,5 +147,118 @@ class FXMacroDataPriceReaderTest(unittest.TestCase):
         self.assertTrue(pd.api.types.is_integer_dtype(data["time"]))
 
 
+class FXMacroDataMacroReaderTest(unittest.TestCase):
+    def setUp(self):
+        self.fxmacrodata = load_fxmacrodata_module()
+
+    def test_announcement_reader_fetches_macro_events(self):
+        requests = []
+
+        def mock_get(url, params, headers, timeout):
+            requests.append((url, params, headers, timeout))
+            return FXMacroDataResponse(
+                {
+                    "data": [
+                        {
+                            "announcement_id": "usd_inflation_2026-05-31",
+                            "date": "2026-05-31",
+                            "val": 4.2,
+                            "announcement_datetime": 1781094600,
+                        }
+                    ]
+                }
+            )
+
+        with patch.object(self.fxmacrodata.requests, "get", side_effect=mock_get):
+            reader = self.fxmacrodata.FXMacroDataAnnouncementReader(
+                "USD",
+                "inflation",
+                "2026-01-01",
+                "2026-06-30",
+                limit=5,
+                api_key=API_KEY,
+                base_url="https://example.com/api/v1",
+            )
+
+        url, params, headers, timeout = requests[0]
+        self.assertEqual(url, "https://example.com/api/v1/announcements/usd/inflation")
+        self.assertEqual(
+            params,
+            {"start_date": "2026-01-01", "end_date": "2026-06-30", "limit": 5},
+        )
+        self.assertEqual(headers, {"X-API-Key": API_KEY})
+        self.assertEqual(timeout, 30)
+        event_data = reader.data["fxmacrodata_announcements_usd_inflation"]
+        self.assertEqual(event_data["time"].tolist(), [1781094600])
+        self.assertEqual(event_data["data"].iloc[0]["val"], 4.2)
+
+    def test_calendar_reader_preserves_events_with_same_timestamp(self):
+        def mock_get(url, params, headers, timeout):
+            return FXMacroDataResponse(
+                {
+                    "data": [
+                        {
+                            "release": "inflation",
+                            "date": "2026-06-30",
+                            "announcement_datetime": 1784032200,
+                            "forecast": 3.9,
+                        },
+                        {
+                            "release": "retail_sales",
+                            "date": "2026-06-30",
+                            "announcement_datetime": 1784032200,
+                            "forecast": 0.2,
+                        },
+                    ]
+                }
+            )
+
+        with patch.object(self.fxmacrodata.requests, "get", side_effect=mock_get):
+            reader = self.fxmacrodata.FXMacroDataCalendarReader(
+                "USD", api_key=API_KEY, base_url="https://example.com/api/v1"
+            )
+
+        event_data = reader.data["fxmacrodata_calendar_usd"]
+        self.assertEqual(event_data["time"].tolist(), [1784032200, 1784032200])
+        self.assertEqual(
+            [row["release"] for row in event_data["data"].tolist()],
+            ["inflation", "retail_sales"],
+        )
+
+    def test_prediction_reader_fetches_forecast_groups(self):
+        def mock_get(url, params, headers, timeout):
+            return FXMacroDataResponse(
+                {
+                    "data": [
+                        {
+                            "announcement_id": "usd_inflation_2026-07-31",
+                            "date": "2026-07-31",
+                            "announcement_datetime": 1786537800,
+                            "predictions": [
+                                {
+                                    "predicted_value": 3.81,
+                                    "prediction_type": "fxmacrodata",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            )
+
+        with patch.object(self.fxmacrodata.requests, "get", side_effect=mock_get):
+            reader = self.fxmacrodata.FXMacroDataPredictionReader(
+                "USD",
+                "inflation",
+                api_key=API_KEY,
+                base_url="https://example.com/api/v1",
+            )
+
+        event_data = reader.data["fxmacrodata_predictions_usd_inflation"]
+        self.assertEqual(event_data["time"].tolist(), [1786537800])
+        self.assertEqual(
+            event_data["data"].iloc[0]["predictions"][0]["predicted_value"], 3.81
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a small `FXMacroDataClient` for FXMacroData REST API access
- keep `FXMacroDataPriceReader` for daily FX spot rates
- add macro event readers for realized announcements, release calendars, and prediction groups
- document price and macro-event usage and add mocked unit coverage

## Notes
The macro readers expose FXMacroData's core event surfaces through Blankly event data: `/announcements/{currency}/{indicator}`, `/calendar/{currency}`, and `/predictions/{currency}/{indicator}`. The price reader remains available for Blankly's `KeylessExchange` and other `PriceReader` workflows.

## Validation
- `python -m py_compile blankly\data\fxmacrodata.py tests\data\test_fxmacrodata_price_reader.py`
- `python -m pytest tests\data\test_fxmacrodata_price_reader.py -q` (6 passed)
- `git diff --check`